### PR TITLE
feat: add support for ssh-ed25519 key signature

### DIFF
--- a/modules/transfer-users/variables.tf
+++ b/modules/transfer-users/variables.tf
@@ -17,9 +17,9 @@ variable "users" {
   validation {
     condition = alltrue([
       for user in var.users :
-      can(regex("^(ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521)\\s+[A-Za-z0-9+/]+={0,2}\\s*$", user.public_key))
+      can(regex("^(ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521|ssh-ed25519)\\s+[A-Za-z0-9+/]+={0,2}\\s*$", user.public_key))
     ])
-    error_message = "Public key must be in the format '<key-type> <base64-encoded-key>' where key-type is one of: ssh-rsa, ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, or ecdsa-sha2-nistp521. Comments are not allowed."
+    error_message = "Public key must be in the format '<key-type> <base64-encoded-key>' where key-type is one of: ssh-rsa, ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, ecdsa-sha2-nistp521 or ssh-ed25519. Comments are not allowed."
   }
 
   validation {


### PR DESCRIPTION
Hi there 👋

Thank you for this useful module! 
I created this PR to add support for ssh-ed25519 key signature.

It is supported by the official AWS docs as mentioned here https://docs.aws.amazon.com/transfer/latest/userguide/key-management.html but not in the module yet.

Cheers

Closes https://github.com/aws-ia/terraform-aws-transfer-family/issues/17