### PR TITLE
Static_tests now runs terraform-docs on examples folder

### DIFF
--- a/.project_automation/static_tests/static_tests.sh
+++ b/.project_automation/static_tests/static_tests.sh
@@ -71,7 +71,16 @@ fi
 #********** Terraform Docs *************
 echo 'Starting terraform-docs'
 TDOCS="$(terraform-docs --config ${PROJECT_PATH}/.config/.terraform-docs.yaml --lockfile=false ./ --recursive)"
-git add -N README.md
+
+# Process examples directories individually
+for example_dir in examples/*/; do
+  if [ -d "$example_dir" ] && [ -f "${example_dir}main.tf" ]; then
+    echo "Processing terraform-docs for $example_dir"
+    terraform-docs --config ${PROJECT_PATH}/.config/.terraform-docs.yaml --lockfile=false "$example_dir"
+  fi
+done
+
+git add -N README.md examples/*/README.md
 GDIFF="$(git diff --compact-summary)"
 if [ -z "$GDIFF" ]
 then

--- a/examples/sftp-internet-facing-vpc-endpoint-service-managed-S3/README.md
+++ b/examples/sftp-internet-facing-vpc-endpoint-service-managed-S3/README.md
@@ -1,5 +1,5 @@
 <!-- BEGIN_TF_DOCS -->
-# AWS Transfer Family: SFTP Server with Internet Facing Internet Facing VPC Endpoint with Service Managed Users
+# AWS Transfer Family: SFTP Server with Internet Facing VPC Endpoint with Service Managed Users
 
 This example demonstrates an AWS Transfer Family SFTP server deployment with a VPC endpoint with service managed users, and S3 storage integration.
 
@@ -10,13 +10,9 @@ This example configures:
 - VPC SFTP endpoint with service-managed users
   - Internet-facing endpoint using Elastic IP addresses
   - (Note: Omitting `address_allocation_ids` would create an internal VPC endpoint)
-  - Internet-facing endpoint using Elastic IP addresses
-  - (Note: Omitting `address_allocation_ids` would create an internal VPC endpoint)
 - Secure S3 bucket with KMS encryption
 - User import through CSV configuration
 - CloudWatch logging with customizable retention
-- Configurable security groups with CIDR-based access control
-- Optional workflow integration for file processing
 - Configurable security groups with CIDR-based access control
 - Optional workflow integration for file processing
 
@@ -25,8 +21,6 @@ This example configures:
 ### Server Configuration
 
 - VPC SFTP endpoint deployment
-  - Internet-facing endpoint when `address_allocation_ids` are specified
-  - Internal endpoint when `address_allocation_ids` are not specified
   - Internet-facing endpoint when `address_allocation_ids` are specified
   - Internal endpoint when `address_allocation_ids` are not specified
 - Service-managed authentication system
@@ -46,8 +40,6 @@ This example configures:
 - Service-managed authentication
 - CloudWatch logging
 - IAM role-based access control
-- Configurable CIDR-based access control for ingress and egress traffic
-- KMS key rotation enabled for encryption keys
 - Configurable CIDR-based access control for ingress and egress traffic
 - KMS key rotation enabled for encryption keys
 
@@ -76,11 +68,9 @@ role_arn: (Optional) Custom IAM role ARN
 #### Implementation
 
 The user import is handled by the transfer-users module:
-The user import is handled by the transfer-users module:
 
 ```
 Located in: modules/transfer-users
-Called by: examples/sftp-internet-facing-vpc-endpoint-service-managed-S3
 Called by: examples/sftp-internet-facing-vpc-endpoint-service-managed-S3
 ```
 
@@ -91,11 +81,9 @@ module "sftp_users" {
     source = "../../modules/transfer-users"
     users = local.users
     create_test_user = true # Test user is for demo purposes
-    create_test_user = true # Test user is for demo purposes
     server_id = module.transfer_server.server_id
     s3_bucket_name = module.s3_bucket.s3_bucket_id
     s3_bucket_arn = module.s3_bucket.s3_bucket_arn
-    kms_key_id = aws_kms_key.transfer_family_key.arn
     kms_key_id = aws_kms_key.transfer_family_key.arn
 }
 ```
@@ -173,39 +161,12 @@ Key points about VPC endpoint types:
 - Internet-facing endpoints require Elastic IPs and public subnets
 - **Internal endpoint**: Created when `address_allocation_ids` are omitted
 - Internal endpoints are only accessible from within the VPC or connected networks
-- Configurable CIDR blocks for SFTP ingress and egress traffic
-- Latest security policy (TransferSecurityPolicy-2024-01) applied
-
-## VPC Endpoint Configuration
-
-This example demonstrates an internet-facing VPC endpoint configuration:
-
-```hcl
-module "transfer_server" {
-  # Other configurations go here
-
-  endpoint_type = "VPC"
-  endpoint_details = {
-    address_allocation_ids = aws_eip.sftp[*].allocation_id  # Makes the endpoint internet-facing
-    security_group_ids     = [aws_security_group.sftp.id]
-    subnet_ids             = local.public_subnets
-    vpc_id                 = local.vpc_id
-  }
-}
-```
-
-Key points about VPC endpoint types:
-
-- **Internet-facing endpoint**: Created when `address_allocation_ids` are specified (as shown in this example)
-- Internet-facing endpoints require Elastic IPs and public subnets
-- **Internal endpoint**: Created when `address_allocation_ids` are omitted
-- Internal endpoints are only accessible from within the VPC or connected networks
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.95.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.24.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
@@ -221,25 +182,19 @@ Key points about VPC endpoint types:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | v5.0.0 |
 | <a name="module_sftp_users"></a> [sftp\_users](#module\_sftp\_users) | ../../modules/transfer-users | n/a |
 | <a name="module_transfer_server"></a> [transfer\_server](#module\_transfer\_server) | ../.. | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/aws-ia/terraform-aws-vpc.git | da49a30fbfeb3890076b783be0abf8639f96f431 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/aws-ia/terraform-aws-vpc.git | da49a30fbfeb3890076b783be0abf8639f96f431 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/aws-ia/terraform-aws-vpc.git | v4.5.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_eip.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
-| [aws_eip.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_kms_alias.transfer_family_key_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.transfer_family_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.transfer_family_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
-| [aws_security_group.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_vpc_security_group_egress_rule.sftp_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.sftp_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_security_group.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.sftp_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.sftp_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
@@ -251,17 +206,11 @@ Key points about VPC endpoint types:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_sftp_ingress_cidr_block"></a> [sftp\_ingress\_cidr\_block](#input\_sftp\_ingress\_cidr\_block) | List of CIDR blocks allowed to access SFTP. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | n/a | yes |
-| <a name="input_sftp_ingress_cidr_block"></a> [sftp\_ingress\_cidr\_block](#input\_sftp\_ingress\_cidr\_block) | List of CIDR blocks allowed to access SFTP. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"us-east-1"` | no |
 | <a name="input_custom_hostname"></a> [custom\_hostname](#input\_custom\_hostname) | The custom hostname for the Transfer Family server | `string` | `null` | no |
 | <a name="input_dns_provider"></a> [dns\_provider](#input\_dns\_provider) | The DNS provider for the custom hostname. Use null for no custom hostname | `string` | `null` | no |
 | <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
-| <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
 | <a name="input_route53_hosted_zone_name"></a> [route53\_hosted\_zone\_name](#input\_route53\_hosted\_zone\_name) | The name of the Route53 hosted zone to use (must end with a period, e.g., 'example.com.') | `string` | `null` | no |
-| <a name="input_sftp_egress_cidr_block"></a> [sftp\_egress\_cidr\_block](#input\_sftp\_egress\_cidr\_block) | List of CIDR block for outbound traffic from SFTP server. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | `"0.0.0.0/0"` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | Deployment stage | `string` | `"dev"` | no |
-| <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |
-| <a name="input_workflow_details"></a> [workflow\_details](#input\_workflow\_details) | Workflow details to attach to the transfer server | <pre>object({<br/>    on_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>    on_partial_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_sftp_egress_cidr_block"></a> [sftp\_egress\_cidr\_block](#input\_sftp\_egress\_cidr\_block) | List of CIDR block for outbound traffic from SFTP server. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Deployment stage | `string` | `"dev"` | no |
 | <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |

--- a/examples/sftp-internet-facing-vpc-endpoint-service-managed-S3/README.md
+++ b/examples/sftp-internet-facing-vpc-endpoint-service-managed-S3/README.md
@@ -76,6 +76,7 @@ role_arn: (Optional) Custom IAM role ARN
 #### Implementation
 
 The user import is handled by the transfer-users module:
+The user import is handled by the transfer-users module:
 
 ```
 Located in: modules/transfer-users
@@ -221,8 +222,10 @@ Key points about VPC endpoint types:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
 | <a name="module_sftp_users"></a> [sftp\_users](#module\_sftp\_users) | ../../modules/transfer-users | n/a |
 | <a name="module_transfer_server"></a> [transfer\_server](#module\_transfer\_server) | ../.. | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/aws-ia/terraform-aws-vpc.git | da49a30fbfeb3890076b783be0abf8639f96f431 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/aws-ia/terraform-aws-vpc.git | da49a30fbfeb3890076b783be0abf8639f96f431 |
 
 ## Resources
@@ -230,9 +233,13 @@ Key points about VPC endpoint types:
 | Name | Type |
 |------|------|
 | [aws_eip.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_eip.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_kms_alias.transfer_family_key_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.transfer_family_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.transfer_family_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
+| [aws_security_group.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.sftp_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.sftp_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_security_group.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.sftp_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.sftp_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
@@ -244,11 +251,17 @@ Key points about VPC endpoint types:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_sftp_ingress_cidr_block"></a> [sftp\_ingress\_cidr\_block](#input\_sftp\_ingress\_cidr\_block) | List of CIDR blocks allowed to access SFTP. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | n/a | yes |
+| <a name="input_sftp_ingress_cidr_block"></a> [sftp\_ingress\_cidr\_block](#input\_sftp\_ingress\_cidr\_block) | List of CIDR blocks allowed to access SFTP. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"us-east-1"` | no |
 | <a name="input_custom_hostname"></a> [custom\_hostname](#input\_custom\_hostname) | The custom hostname for the Transfer Family server | `string` | `null` | no |
 | <a name="input_dns_provider"></a> [dns\_provider](#input\_dns\_provider) | The DNS provider for the custom hostname. Use null for no custom hostname | `string` | `null` | no |
 | <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
+| <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
 | <a name="input_route53_hosted_zone_name"></a> [route53\_hosted\_zone\_name](#input\_route53\_hosted\_zone\_name) | The name of the Route53 hosted zone to use (must end with a period, e.g., 'example.com.') | `string` | `null` | no |
+| <a name="input_sftp_egress_cidr_block"></a> [sftp\_egress\_cidr\_block](#input\_sftp\_egress\_cidr\_block) | List of CIDR block for outbound traffic from SFTP server. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Deployment stage | `string` | `"dev"` | no |
+| <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |
+| <a name="input_workflow_details"></a> [workflow\_details](#input\_workflow\_details) | Workflow details to attach to the transfer server | <pre>object({<br/>    on_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>    on_partial_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_sftp_egress_cidr_block"></a> [sftp\_egress\_cidr\_block](#input\_sftp\_egress\_cidr\_block) | List of CIDR block for outbound traffic from SFTP server. To set multiple cidr blocks seperate with comma '10.0.0.0/24, 10.0.1.0/24' | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Deployment stage | `string` | `"dev"` | no |
 | <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |

--- a/examples/sftp-public-endpoint-service-managed-S3/README.md
+++ b/examples/sftp-public-endpoint-service-managed-S3/README.md
@@ -148,6 +148,7 @@ module "transfer_server" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
 | <a name="module_sftp_users"></a> [sftp\_users](#module\_sftp\_users) | ../../modules/transfer-users | n/a |
 | <a name="module_transfer_server"></a> [transfer\_server](#module\_transfer\_server) | ../.. | n/a |
 
@@ -169,7 +170,10 @@ module "transfer_server" {
 | <a name="input_custom_hostname"></a> [custom\_hostname](#input\_custom\_hostname) | The custom hostname for the Transfer Family server | `string` | `null` | no |
 | <a name="input_dns_provider"></a> [dns\_provider](#input\_dns\_provider) | The DNS provider for the custom hostname. Use null for no custom hostname | `string` | `null` | no |
 | <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
+| <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
 | <a name="input_route53_hosted_zone_name"></a> [route53\_hosted\_zone\_name](#input\_route53\_hosted\_zone\_name) | The name of the Route53 hosted zone to use (must end with a period, e.g., 'example.com.') | `string` | `null` | no |
+| <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |
+| <a name="input_workflow_details"></a> [workflow\_details](#input\_workflow\_details) | Workflow details to attach to the transfer server | <pre>object({<br/>    on_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>    on_partial_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |
 | <a name="input_workflow_details"></a> [workflow\_details](#input\_workflow\_details) | Workflow details to attach to the transfer server | <pre>object({<br/>    on_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>    on_partial_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>  })</pre> | `null` | no |
 

--- a/examples/sftp-public-endpoint-service-managed-S3/README.md
+++ b/examples/sftp-public-endpoint-service-managed-S3/README.md
@@ -131,7 +131,7 @@ module "transfer_server" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.95.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.24.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
@@ -147,8 +147,7 @@ module "transfer_server" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | fc09cc6fb779b262ce1bee5334e85808a107d8a3 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git | v5.0.0 |
 | <a name="module_sftp_users"></a> [sftp\_users](#module\_sftp\_users) | ../../modules/transfer-users | n/a |
 | <a name="module_transfer_server"></a> [transfer\_server](#module\_transfer\_server) | ../.. | n/a |
 
@@ -170,10 +169,7 @@ module "transfer_server" {
 | <a name="input_custom_hostname"></a> [custom\_hostname](#input\_custom\_hostname) | The custom hostname for the Transfer Family server | `string` | `null` | no |
 | <a name="input_dns_provider"></a> [dns\_provider](#input\_dns\_provider) | The DNS provider for the custom hostname. Use null for no custom hostname | `string` | `null` | no |
 | <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
-| <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN that the Transfer Server assumes to write logs to CloudWatch Logs | `string` | `null` | no |
 | <a name="input_route53_hosted_zone_name"></a> [route53\_hosted\_zone\_name](#input\_route53\_hosted\_zone\_name) | The name of the Route53 hosted zone to use (must end with a period, e.g., 'example.com.') | `string` | `null` | no |
-| <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |
-| <a name="input_workflow_details"></a> [workflow\_details](#input\_workflow\_details) | Workflow details to attach to the transfer server | <pre>object({<br/>    on_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>    on_partial_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_users_file"></a> [users\_file](#input\_users\_file) | Path to CSV file containing user configurations | `string` | `null` | no |
 | <a name="input_workflow_details"></a> [workflow\_details](#input\_workflow\_details) | Workflow details to attach to the transfer server | <pre>object({<br/>    on_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>    on_partial_upload = optional(object({<br/>      execution_role = string<br/>      workflow_id    = string<br/>    }))<br/>  })</pre> | `null` | no |
 


### PR DESCRIPTION
the static tests were not running terraform-docs on the examples folder. Now they do!

This resolves the issue [#48](https://github.com/aws-ia/terraform-aws-transfer-family/issues/48) 