### PR TITLE
Hotfix/extract iam role from connector module

### DIFF
--- a/examples/sftp-connector-automated-file-retrieve-dynamic/README.md
+++ b/examples/sftp-connector-automated-file-retrieve-dynamic/README.md
@@ -209,6 +209,8 @@ You can monitor the discovery and retrieval process by checking:
 | [aws_cloudwatch_event_rule.transfer_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.event_listener_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_dynamodb_table.file_transfer_tracking](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_iam_policy.connector_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.connector_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.event_listener_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.scheduler_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -217,6 +219,7 @@ You can monitor the discovery and retrieval process by checking:
 | [aws_iam_role_policy.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.status_checker_scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.connector_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.transfer_family_key_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.transfer_family_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.transfer_family_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
@@ -234,6 +237,7 @@ You can monitor the discovery and retrieval process by checking:
 | [archive_file.event_listener_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.lambda_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_kms_key.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 

--- a/examples/sftp-connector-automated-file-retrieve-static/README.md
+++ b/examples/sftp-connector-automated-file-retrieve-static/README.md
@@ -182,13 +182,16 @@ You can monitor the retrieval process by checking:
 | [aws_cloudwatch_event_rule.transfer_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.event_listener_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_dynamodb_table.file_transfer_tracking](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_iam_policy.connector_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.dynamodb_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.connector_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.event_listener_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.scheduler_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.status_checker_scheduler_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.event_listener_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.status_checker_scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.connector_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.scheduler_dynamodb_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.transfer_family_key_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.transfer_family_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
@@ -203,6 +206,7 @@ You can monitor the retrieval process by checking:
 | [random_pet.name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [archive_file.event_listener_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_kms_key.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 

--- a/examples/sftp-connector-automated-file-retrieve-static/main.tf
+++ b/examples/sftp-connector-automated-file-retrieve-static/main.tf
@@ -13,28 +13,134 @@ resource "random_pet" "name" {
   length = 1
 }
 
-locals {
-  connector_name = "retrieve-${random_pet.name.id}"
-}
-
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-# Get KMS key from existing secret if provided (only when not destroying)
+locals {
+  connector_name = "retrieve-${random_pet.name.id}"
+  create_secret = var.existing_secret_arn == null
+  kms_key_arn = local.create_secret ? aws_kms_key.transfer_family_key[0].arn : data.aws_kms_key.existing[0].arn
+}
+
+# Get KMS key from existing secret if provided
 data "aws_secretsmanager_secret" "existing" {
-  count = var.existing_secret_arn != null && var.existing_secret_arn != "" ? 1 : 0
+  count = local.create_secret ? 0 : 1
   arn   = var.existing_secret_arn
+}
+
+# Get KMS key details from existing secret
+data "aws_kms_key" "existing" {
+  count  = local.create_secret ? 0 : 1
+  key_id = data.aws_secretsmanager_secret.existing[0].kms_key_id
+}
+
+###################################################################
+# SFTP Connector
+###################################################################
+module "sftp_connector" {
+  source = "../../modules/transfer-connectors"
+
+  connector_name                  = local.connector_name
+  url                             = var.sftp_server_endpoint
+  access_role                     = aws_iam_role.connector_role.arn
+
+  # Use existing secret or create new one
+  user_secret_id                  = var.existing_secret_arn
+  secret_name                     = local.create_secret ? "sftp-credentials-${random_pet.name.id}" : null
+  sftp_username                   = var.sftp_username
+  sftp_private_key                = var.sftp_private_key
+  trusted_host_keys               = var.trusted_host_keys
+  secrets_manager_kms_key_arn     = local.kms_key_arn
+  security_policy_name            = "TransferSFTPConnectorSecurityPolicy-2024-03"
+  test_connector_post_deployment  = var.test_connector_post_deployment
+
+  tags = {
+    Environment = "Demo"
+    Project     = "SFTP Connector Retrieve"
+  }
+}
+
+#####################################################################################
+# IAM Role and Policy for the SFTP Connector
+#####################################################################################
+
+resource "aws_iam_role" "connector_role" {
+  name = "transfer-connector-role-${local.connector_name}"
+  
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "transfer.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# This policy is based off the example from the official AWS documentation https://docs.aws.amazon.com/transfer/latest/userguide/create-sftp-connector-procedure.html
+resource "aws_iam_policy" "connector_policy" {
+  name        = "transfer-connector-policy-${local.connector_name}"
+  description = "Policy for AWS Transfer Family SFTP connector"
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Sid = "AllowListingOfUserFolder",
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = module.retrieve_s3_bucket.s3_bucket_arn
+      },
+      {
+        Sid = "HomeDirObjectAccess",
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:DeleteObjectVersion",
+          "s3:GetObjectVersion",
+          "s3:GetObjectACL",
+          "s3:PutObjectACL"
+        ]
+        Resource = "${module.retrieve_s3_bucket.s3_bucket_arn}/*"
+      },
+    ], local.create_secret ? [] : [{
+      Sid = "GetConnectorSecretValue",
+      Effect = "Allow"
+      Action = [
+        "secretsmanager:GetSecretValue"
+      ]
+      Resource = var.existing_secret_arn
+    }], local.kms_key_arn != null ? [{
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+      Resource = local.kms_key_arn
+    }] : [])
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "connector_policy_attachment" {
+  role       = aws_iam_role.connector_role.name
+  policy_arn = aws_iam_policy.connector_policy.arn
 }
 
 ###################################################################
 # Use existing KMS Key from the secret
 ###################################################################
-locals {
-  kms_key_arn = var.existing_secret_arn != null ? data.aws_secretsmanager_secret.existing[0].kms_key_id : aws_kms_key.transfer_family_key[0].arn
-}
 
 resource "aws_kms_key" "transfer_family_key" {
-  count = var.existing_secret_arn == null ? 1 : 0
+  count = local.create_secret ? 1 : 0
   
   description             = "KMS key for encrypting S3 bucket, CloudWatch logs and connector credentials"
   deletion_window_in_days = 7
@@ -101,14 +207,14 @@ resource "aws_kms_key" "transfer_family_key" {
 }
 
 resource "aws_kms_alias" "transfer_family_key_alias" {
-  count = var.existing_secret_arn == null ? 1 : 0
+  count = local.create_secret ? 1 : 0
   
   name          = "alias/transfer-family-retrieve-key-${random_pet.name.id}"
   target_key_id = aws_kms_key.transfer_family_key[0].key_id
 }
 
 resource "aws_kms_key_policy" "transfer_family_key_policy" {
-  count = var.existing_secret_arn == null ? 1 : 0
+  count = local.create_secret ? 1 : 0
   
   key_id = aws_kms_key.transfer_family_key[0].id
   policy = aws_kms_key.transfer_family_key[0].policy
@@ -141,35 +247,6 @@ module "retrieve_s3_bucket" {
         sse_algorithm     = "aws:kms"
       }
     }
-  }
-}
-
-###################################################################
-# SFTP Connector
-###################################################################
-module "sftp_connector" {
-  source = "../../modules/transfer-connectors"
-
-  connector_name    = local.connector_name
-  url               = var.sftp_server_endpoint
-  s3_bucket_arn     = module.retrieve_s3_bucket.s3_bucket_arn
-
-  # Use existing secret or create new one
-  user_secret_id                  = var.existing_secret_arn
-  secret_name                     = var.existing_secret_arn == null ? "sftp-credentials-${random_pet.name.id}" : null
-  secret_kms_key_id               = var.existing_secret_arn == null ? aws_kms_key.transfer_family_key[0].arn : null
-  sftp_username                   = var.sftp_username
-  sftp_private_key                = var.sftp_private_key
-  trusted_host_keys               = var.trusted_host_keys
-
-  S3_kms_key_arn                  = local.kms_key_arn
-  secrets_manager_kms_key_arn     = local.kms_key_arn
-  security_policy_name            = "TransferSFTPConnectorSecurityPolicy-2024-03"
-  test_connector_post_deployment  = var.test_connector_post_deployment
-
-  tags = {
-    Environment = "Demo"
-    Project     = "SFTP Connector Retrieve"
   }
 }
 

--- a/examples/sftp-connector-automated-file-send/README.md
+++ b/examples/sftp-connector-automated-file-send/README.md
@@ -175,8 +175,11 @@ You can monitor the transfer process by checking:
 |------|------|
 | [aws_cloudwatch_event_rule.s3_object_created](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.lambda_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_policy.connector_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.connector_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.connector_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.transfer_family_key_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.transfer_family_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
@@ -192,6 +195,7 @@ You can monitor the transfer process by checking:
 | [archive_file.lambda_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.lambda_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_key.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 
 ## Inputs

--- a/modules/transfer-connectors/README.md
+++ b/modules/transfer-connectors/README.md
@@ -27,14 +27,12 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.connector_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.connector_logging_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.connector_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.rotation_lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.access_role_secrets_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.connector_logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.connector_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.rotation_lambda_basic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.allow_secretsmanager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
@@ -44,6 +42,7 @@ No modules.
 | [aws_transfer_connector.sftp_connector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_connector) | resource |
 | [random_id.connector_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [terraform_data.discover_and_test_connector](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.trusted_host_keys_warning](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.rotation_lambda_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -53,12 +52,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_s3_bucket_arn"></a> [s3\_bucket\_arn](#input\_s3\_bucket\_arn) | ARN of the S3 bucket to connect to the SFTP server | `string` | n/a | yes |
+| <a name="input_access_role"></a> [access\_role](#input\_access\_role) | ARN of the IAM role to attach to the SFTP connector | `string` | n/a | yes |
 | <a name="input_url"></a> [url](#input\_url) | URL of the SFTP server to connect to (e.g., example.com or sftp://example.com:22) | `string` | n/a | yes |
-| <a name="input_S3_kms_key_arn"></a> [S3\_kms\_key\_arn](#input\_S3\_kms\_key\_arn) | ARN of the KMS key used for encryption (optional) | `string` | `null` | no |
 | <a name="input_connector_name"></a> [connector\_name](#input\_connector\_name) | Name of the AWS Transfer Family connector | `string` | `"sftp-connector"` | no |
 | <a name="input_logging_role"></a> [logging\_role](#input\_logging\_role) | IAM role ARN for CloudWatch logging (if not provided, a new role will be created) | `string` | `null` | no |
-| <a name="input_secret_kms_key_id"></a> [secret\_kms\_key\_id](#input\_secret\_kms\_key\_id) | KMS key ID for encrypting the secret | `string` | `null` | no |
 | <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Name for the new secret (only used when create\_secret is true) | `string` | `null` | no |
 | <a name="input_secrets_manager_kms_key_arn"></a> [secrets\_manager\_kms\_key\_arn](#input\_secrets\_manager\_kms\_key\_arn) | ARN of the KMS key used to encrypt the secrets manager secret containing SFTP credentials | `string` | `null` | no |
 | <a name="input_security_policy_name"></a> [security\_policy\_name](#input\_security\_policy\_name) | The name of the security policy to use for the connector (must be in the format TransferSFTPConnectorSecurityPolicy-*) | `string` | `"TransferSFTPConnectorSecurityPolicy-2024-03"` | no |

--- a/modules/transfer-connectors/outputs.tf
+++ b/modules/transfer-connectors/outputs.tf
@@ -19,7 +19,7 @@ output "connector_url" {
 
 output "connector_role_arn" {
   description = "The ARN of the IAM role used by the connector"
-  value       = aws_iam_role.connector_role.arn
+  value       = var.access_role
 }
 
 output "connector_logging_role_arn" {

--- a/modules/transfer-connectors/variables.tf
+++ b/modules/transfer-connectors/variables.tf
@@ -18,17 +18,16 @@ variable "url" {
   }
 }
 
-variable "s3_bucket_arn" {
-  description = "ARN of the S3 bucket to connect to the SFTP server"
+variable "access_role" {
+  description = "ARN of the IAM role to attach to the SFTP connector"
   type        = string
 
   validation {
-    condition     = can(regex("^arn:aws:s3:::[a-z0-9.-]+$", var.s3_bucket_arn))
-    error_message = "S3 bucket ARN must be in the format: arn:aws:s3:::bucket-name"
+    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.+$", var.access_role))
+    error_message = "Access role must be a valid IAM role ARN."
   }
+
 }
-
-
 
 variable "user_secret_id" {
   description = "ARN of the AWS Secrets Manager secret containing SFTP credentials (optional - will auto-detect for AWS Transfer Family servers)"
@@ -54,12 +53,6 @@ variable "security_policy_name" {
 
 variable "logging_role" {
   description = "IAM role ARN for CloudWatch logging (if not provided, a new role will be created)"
-  type        = string
-  default     = null
-}
-
-variable "S3_kms_key_arn" {
-  description = "ARN of the KMS key used for encryption (optional)"
   type        = string
   default     = null
 }
@@ -97,12 +90,6 @@ variable "sftp_private_key" {
 
 variable "secret_name" {
   description = "Name for the new secret (only used when create_secret is true)"
-  type        = string
-  default     = null
-}
-
-variable "secret_kms_key_id" {
-  description = "KMS key ID for encrypting the secret"
   type        = string
   default     = null
 }

--- a/tests/01_mandatory.tftest.hcl
+++ b/tests/01_mandatory.tftest.hcl
@@ -8,12 +8,14 @@ run "mandatory_plan_basic" {
     source = "./examples/sftp-public-endpoint-service-managed-S3"
   }
 }
+
 run "mandatory_apply_basic" {
   command = apply
   module {
     source = "./examples/sftp-public-endpoint-service-managed-S3"
   }
 }
+
 run "mandatory_plan_vpc" {
   command = plan
   module {
@@ -44,6 +46,7 @@ run "connector_file_send_plan" {
     existing_secret_arn = run.mandatory_apply_basic.test_user_secret.private_key_secret.arn
   }
 }
+
 run "connector_file_send_apply" {
   command = apply
   module {


### PR DESCRIPTION
# Extract IAM Role Creation from SFTP Connector Module

## Summary
This PR separates the IAM role creation process from the SFTP connector module, aligning more closely with the user experience in the console and providing greater flexibility for IAM role management.

## Changes
- Extracted IAM role creation logic from the SFTP connector module
- Removed the requirement to pass S3 bucket ARN as a variable to the connector module

## Benefits
1. **Improved User Experience**: This change better reflects the process of creating SFTP connectors in the console.
2. **Enhanced Flexibility**: Customers now have more control over IAM role creation and management.
3. **Simplified Module**: The SFTP connector module is now more focused and easier to maintain.