### PR TITLE
changes the way we extract the PR title from git history

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get latest commit message
         id: commit
-        run: echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+        run: echo "message=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
 
       - name: Determine version bump type
         id: bump-type


### PR DESCRIPTION
So it turns out that the version bump action had a slight mistake that caused it to fail. The PR fixes this issue by changing the way we extract the PR title from the git history.

`run: echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT` was changed to `run: echo "message=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT`

I also found a way to test this locally so it should work 🤞 