### PR TITLE
fix(transfer-connectors): use var.logging_role ARN when provided (#117)

### DIFF
--- a/modules/transfer-connectors/main.tf
+++ b/modules/transfer-connectors/main.tf
@@ -10,7 +10,7 @@
 data "aws_caller_identity" "current" {}
 locals {
   should_scan = false
-  logging_role = length(aws_iam_role.connector_logging_role) > 0 ? aws_iam_role.connector_logging_role[0].arn : null
+  logging_role = var.logging_role != null ? var.logging_role : (length(aws_iam_role.connector_logging_role) > 0 ? aws_iam_role.connector_logging_role[0].arn : null)
   
   # Use provided secret ID or create new one
   effective_secret_id = var.user_secret_id != null ? var.user_secret_id : (local.create_secret ? aws_secretsmanager_secret.sftp_credentials[0].arn : null)


### PR DESCRIPTION
## What

When an external logging role ARN is passed via `var.logging_role`, the connector is created with a `null` logging role instead of the provided ARN.

`local.logging_role` (in `modules/transfer-connectors/main.tf`) only resolves to the module-created role:

    logging_role = length(aws_iam_role.connector_logging_role) > 0 ? aws_iam_role.connector_logging_role[0].arn : null

But when `var.logging_role` is set, the `connector_logging_role` resource has `count = 0`, so `length(...) == 0` and the local falls through to `null`. The connector resource (and the post-deploy CLI test) then receive `null`.

## Fix

Prefer the caller-provided `var.logging_role`, falling back to the module-created role:

    logging_role = var.logging_role != null ? var.logging_role : (length(aws_iam_role.connector_logging_role) > 0 ? aws_iam_role.connector_logging_role[0].arn : null)

This matches the existing `effective_secret_id` pattern in the same locals block.

## Testing

- `terraform validate` passes.
- With `logging_role` set to an external ARN, the connector's `logging_role` is now that ARN (previously null). Module-created-role behavior is unchanged.

Fixes #117