### PR TITLE
fix: prevent script injection in sync-transfer-server-module workflow

### DIFF
--- a/.github/workflows/sync-transfer-server-module.yml
+++ b/.github/workflows/sync-transfer-server-module.yml
@@ -40,8 +40,10 @@ jobs:
           git-push: false  # Important: Don't push here, we'll do it in the next step
 
       - name: Commit all changes
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add modules/transfer-server/
-          git diff --staged --quiet || (git commit -m "chore: sync transfer-server module files and update documentation" && git push origin ${{ github.head_ref }})
+          git diff --staged --quiet || (git commit -m "chore: sync transfer-server module files and update documentation" && git push origin "$HEAD_REF")


### PR DESCRIPTION
Move the attacker-controlled github.head_ref out of the inline shell script and into an environment variable, then reference the quoted shell variable "$HEAD_REF" in the git push command. This prevents ${{ github.head_ref }} from being expanded into the command line, where a maliciously named PR branch could execute arbitrary commands on the runner (which holds contents: write and GITHUB_TOKEN).

Verified with acat-cli: HIGH-severity 'Script Injection in GitHub Actions workflows' finding cleared (1 finding -> 0 findings).