### PR TITLE
Bump random_pet length from 1 to 2 to reduce name collisions in tests

### DIFF
--- a/examples/sftp-connector-automated-file-retrieve-dynamic/main.tf
+++ b/examples/sftp-connector-automated-file-retrieve-dynamic/main.tf
@@ -10,7 +10,7 @@
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/examples/sftp-connector-automated-file-retrieve-static/main.tf
+++ b/examples/sftp-connector-automated-file-retrieve-static/main.tf
@@ -10,7 +10,7 @@
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/examples/sftp-connector-automated-file-send/main.tf
+++ b/examples/sftp-connector-automated-file-send/main.tf
@@ -10,7 +10,7 @@
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/examples/sftp-idp-cognito-lambda/main.tf
+++ b/examples/sftp-idp-cognito-lambda/main.tf
@@ -10,7 +10,7 @@ data "aws_caller_identity" "current" {}
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/examples/sftp-idp-entra-lambda/main.tf
+++ b/examples/sftp-idp-entra-lambda/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/examples/sftp-idp-okta/main.tf
+++ b/examples/sftp-idp-okta/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/examples/sftp-internet-facing-vpc-endpoint-service-managed-S3/main.tf
+++ b/examples/sftp-internet-facing-vpc-endpoint-service-managed-S3/main.tf
@@ -10,7 +10,7 @@
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/examples/sftp-public-endpoint-service-managed-S3/main.tf
+++ b/examples/sftp-public-endpoint-service-managed-S3/main.tf
@@ -10,7 +10,7 @@
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 resource "random_id" "suffix" {

--- a/modules/transfer-users/main.tf
+++ b/modules/transfer-users/main.tf
@@ -4,7 +4,7 @@
 
 resource "random_pet" "name" {
   prefix = "aws-ia"
-  length = 1
+  length = 2
 }
 
 locals {


### PR DESCRIPTION
random_pet.name across 9 examples and modules currently rolls a single adjective+animal word (~6,000 unique pets), giving a 50% chance of collision after about 95 deployments. Increasing length to 2 yields ~36 million unique pet pairs, pushing the 50% collision threshold to roughly 7,500 deployments — well above any realistic test cadence.

Files updated:
- examples/sftp-idp-cognito-lambda/main.tf
- examples/sftp-idp-entra-lambda/main.tf
- examples/sftp-idp-okta/main.tf
- examples/sftp-public-endpoint-service-managed-S3/main.tf
- examples/sftp-internet-facing-vpc-endpoint-service-managed-S3/main.tf
- examples/sftp-connector-automated-file-retrieve-static/main.tf
- examples/sftp-connector-automated-file-retrieve-dynamic/main.tf
- examples/sftp-connector-automated-file-send/main.tf
- modules/transfer-users/main.tf

Two of the files also gained a trailing newline (already idiomatic across the rest of the repo).