### PR TITLE
Pin mcp to >=1.11.0,<2.0.0 across agentcore agents

### DIFF
--- a/examples/sftp-automated-workflows-agentcore/agent-source-code/classification_agent/requirements.txt
+++ b/examples/sftp-automated-workflows-agentcore/agent-source-code/classification_agent/requirements.txt
@@ -4,4 +4,4 @@ strands-agents>=0.1.0
 strands-agents-tools>=0.1.0
 boto3>=1.34.0
 httpx>=0.27.0
-mcp>=1.0.0
+mcp>=1.11.0,<2.0.0

--- a/examples/sftp-automated-workflows-agentcore/agent-source-code/damage_assessment_agent/requirements.txt
+++ b/examples/sftp-automated-workflows-agentcore/agent-source-code/damage_assessment_agent/requirements.txt
@@ -4,4 +4,4 @@ strands-agents>=0.1.0
 strands-agents-tools>=0.1.0
 boto3>=1.34.0
 httpx>=0.27.0
-mcp>=1.0.0
+mcp>=1.11.0,<2.0.0

--- a/examples/sftp-automated-workflows-agentcore/agent-source-code/document_extraction_agent/requirements.txt
+++ b/examples/sftp-automated-workflows-agentcore/agent-source-code/document_extraction_agent/requirements.txt
@@ -4,5 +4,5 @@ strands-agents>=0.1.0
 strands-agents-tools>=0.1.0
 boto3>=1.34.0
 httpx>=0.27.0
-mcp>=1.0.0
+mcp>=1.11.0,<2.0.0
 pypdf>=5.0.0

--- a/examples/sftp-automated-workflows-agentcore/agent-source-code/fraud_detection_agent/requirements.txt
+++ b/examples/sftp-automated-workflows-agentcore/agent-source-code/fraud_detection_agent/requirements.txt
@@ -4,4 +4,4 @@ strands-agents>=0.1.0
 strands-agents-tools>=0.1.0
 boto3>=1.34.0
 httpx>=0.27.0
-mcp>=1.0.0
+mcp>=1.11.0,<2.0.0


### PR DESCRIPTION
## Summary
Pins the `mcp` dependency to `>=1.11.0,<2.0.0` across all four AgentCore example agents. The previous unpinned `mcp>=1.0.0` allowed incompatible `mcp` versions to be resolved, which broke the agent flow.

The `1.11.0` lower bound matches the `strands-agents` requirement (`mcp<2.0.0,>=1.11.0`), and the `<2.0.0` upper cap prevents a future breaking major version from being pulled in automatically.

## Files changed
- `examples/sftp-automated-workflows-agentcore/agent-source-code/classification_agent/requirements.txt`
- `examples/sftp-automated-workflows-agentcore/agent-source-code/damage_assessment_agent/requirements.txt`
- `examples/sftp-automated-workflows-agentcore/agent-source-code/document_extraction_agent/requirements.txt`
- `examples/sftp-automated-workflows-agentcore/agent-source-code/fraud_detection_agent/requirements.txt`

## Testing
- Verified all four agent `requirements.txt` files now pin `mcp>=1.11.0,<2.0.0`.
- No other `mcp` pins exist in the repo source.